### PR TITLE
fix: reverse scrolling on mouse

### DIFF
--- a/fire_atlas_editor/lib/screens/editor_screen/widgets/selection_canvas/canvas_board.dart
+++ b/fire_atlas_editor/lib/screens/editor_screen/widgets/selection_canvas/canvas_board.dart
@@ -219,8 +219,8 @@ class CanvasBoardState extends State<CanvasBoard> {
                 onPointerSignal: (s) {
                   if (s is PointerScrollEvent) {
                     setState(() {
-                      _translateX += s.scrollDelta.dx;
-                      _translateY += s.scrollDelta.dy;
+                      _translateX -= s.scrollDelta.dx;
+                      _translateY -= s.scrollDelta.dy;
                     });
                   }
                 },


### PR DESCRIPTION
Fixes the https://github.com/flame-engine/flame/issues/3274

@spydon I think using a negative value in this case is the right approach. However, natural scrolling on a Mac might reverse the behavior. Still, this method feels correct to me, especially when I compare it to touchpad scrolling.